### PR TITLE
Add conversational core with AWS speech integrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Core service secrets
+OPENAI_API_KEY=changeme
+AWS_ACCESS_KEY_ID=changeme
+AWS_SECRET_ACCESS_KEY=changeme
+AWS_REGION=us-east-1
+TWILIO_ACCOUNT_SID=changeme
+TWILIO_AUTH_TOKEN=changeme
+TWILIO_PHONE_NUMBER=+5215555555555
+
+# Database
+DATABASE_URL=postgresql+psycopg2://voice_agent:voice_agent@postgres:5432/voice_agent
+
+# Redis / message bus
+REDIS_URL=redis://redis:6379/0
+
+# Speech synthesis cache
+AUDIO_CACHE_BUCKET=s3://voice-agent-cache
+
+# Observability
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,185 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypa__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Docker
+.dockerignore
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.temp
+
+# Database
+*.db
+*.sqlite
+*.sqlite3
+
+# Secrets
+.env.local
+.env.production
+.env.staging
+
+# Node.js (if any frontend)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+terraform.tfvars
+
+# Kubernetes
+*.yaml.bak
+
+# Build artifacts
+target/
+build/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: format lint up down logs deps
+
+format:
+python -m ruff format services
+
+lint:
+python -m ruff check services
+
+up:
+docker compose up --build
+
+down:
+docker compose down
+
+logs:
+docker compose logs -f
+
+deps:
+pip install -e .[dev]

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 .PHONY: format lint up down logs deps
 
 format:
-python -m ruff format services
+	python -m ruff format services
 
 lint:
-python -m ruff check services
+	python -m ruff check services
 
 up:
-docker compose up --build
+	docker compose up --build
 
 down:
-docker compose down
+	docker compose down
 
 logs:
-docker compose logs -f
+	docker compose logs -f
 
 deps:
-pip install -e .[dev]
+	source venv/bin/activate && pip install ruff pytest

--- a/README.md
+++ b/README.md
@@ -1,1 +1,122 @@
-# voice_agent_caller
+# Voice Agent Caller Platform
+
+A modular, cloud-native platform for running natural-language, Spanish-speaking voice agents that can place and receive phone calls in Mexico, capture structured information, and integrate with enterprise systems.
+
+## Why This Project Exists
+Businesses operating in Mexico need automated phone agents that sound natural in Spanish, comply with local telecom regulations, and can reliably gather customer information. This repository provides the baseline implementation and scaffolding for such a platform.
+
+## High-Level Architecture
+The system is composed of independently deployable FastAPI services, shared infrastructure, and managed cloud offerings:
+
+| Layer | Responsibilities | Technologies |
+| --- | --- | --- |
+| Telephony Edge | Terminate Mexican PSTN calls, validate Twilio webhooks, stream media, ensure compliance prompts. | **Twilio Programmable Voice**, FastAPI, Redis pub/sub |
+| Speech & Voice | Real-time speech recognition and neural TTS for natural Mexican Spanish. | **Amazon Transcribe Streaming**, **Amazon Polly Neural**, WebSocket audio gateway |
+| Conversation Brain | Maintain dialogue state, orchestrate LLM reasoning, fill slots, perform retrieval. | FastAPI, **OpenAI GPT-4o**, Redis, Qdrant vector store, PostgreSQL |
+| Backend APIs | Persist contacts, call outcomes, transcripts, CRM integrations. | FastAPI, **PostgreSQL** (with pgvector), SQLAlchemy |
+| Async Processing | Background tasks for analytics, QA, CRM sync. | **Celery**, Redis, S3-compatible object storage |
+| Observability & Ops | Unified logging, metrics, and traces; alerting and QA review. | **OpenTelemetry**, Prometheus, Grafana, Loki |
+| Infrastructure | Provisioning, secrets, deployment automation. | Terraform, Docker, Kubernetes (future), GitHub Actions |
+
+A more detailed architecture description is available in [`docs/architecture.md`](docs/architecture.md).
+
+## Repository Layout
+```
+├── docker-compose.yml          # Local orchestration of core services and dependencies
+├── services/
+│   ├── telephony_gateway/      # Twilio webhooks and audio streaming bridge
+│   ├── conversation_orchestrator/  # Dialogue manager + LLM integration surface
+│   └── backend_api/            # Persistence, CRM connectors, reporting APIs
+├── docs/
+│   └── architecture.md         # Extended architecture documentation
+├── infra/
+│   └── terraform/              # Terraform modules (placeholders for future build-out)
+├── pyproject.toml              # Shared tooling configuration (ruff, pytest)
+├── Makefile                    # Developer quality-of-life commands
+└── .env.example                # Sample environment variables required to run the stack
+```
+
+## Local Development
+1. **Install dependencies** (Python 3.11+):
+   ```bash
+   python -m pip install --upgrade pip
+   make deps
+   ```
+2. **Start the stack**:
+   ```bash
+   docker compose up --build
+   ```
+3. **Verify health checks**:
+   - Telephony Gateway: <http://localhost:8080/healthz>
+   - Conversation Orchestrator: <http://localhost:8081/healthz>
+   - Backend API: <http://localhost:8082/healthz>
+4. **Run quality checks**:
+   ```bash
+   make lint
+   make format
+   ```
+
+> **Note:** Replace secrets in `.env.example` before deploying to any shared environment. Use AWS Secrets Manager or HashiCorp Vault in production.
+> Ensure valid AWS credentials are exported locally so the telephony gateway can reach Amazon Transcribe and Polly during development.
+
+## Implementation Roadmap
+The delivery plan follows five incremental phases to ensure production readiness:
+
+### Phase 0 – Foundations (Current)
+- Bootstrap FastAPI microservices with Docker builds and shared tooling.
+- Establish code quality workflow (ruff, pytest) and environment templates.
+- Author architecture and operational documentation.
+
+### Phase 1 – Telephony MVP
+- Configure Twilio numbers for Mexican routes and SIP trunks.
+- Implement webhook signature validation, call state persistence, and WebSocket media gateway.
+- Integrate Amazon Transcribe streaming pipeline for live transcription.
+
+### Phase 2 – Conversational Core (Current)
+- Introduce dialogue state store in Redis and session transcript persistence in Postgres/S3.
+- Connect OpenAI GPT-4o for bilingual reasoning; add deterministic slot-filling for compliance flows.
+- Generate Amazon Polly neural Spanish speech with SSML for playback through Twilio `<Stream>` responses.
+
+**Delivered in this repository:**
+- Redis-backed conversation state service with slot-filling dialogue manager and GPT-4o fallback for nuanced Spanish replies.
+- Backend persistence for call sessions and transcript segments, enabling analytics and QA review.
+- Telephony gateway integration with Amazon Transcribe streaming and Polly speech synthesis (with Redis caching) for low-latency natural responses.
+
+### Phase 3 – Retrieval & Integrations (Next)
+- Stand up Qdrant with pgvector-backed metadata syncing for knowledge grounding (FAQs, CRM data).
+- Build CRM connector abstractions (Salesforce, HubSpot) and configure secure credential storage.
+- Implement Celery workers for post-call analytics, QA scoring, and downstream notifications.
+
+### Phase 4 – Experience & Tooling
+- Develop supervisor dashboard (Next.js + Grafana panels) with live transcripts and whisper monitoring.
+- Add consent management, call disposition workflows, and escalation triggers.
+- Automate regression testing (Pytest + pytest-asyncio) and load testing (k6) in CI/CD.
+
+### Phase 5 – Hardening & Scale
+- Deploy to Kubernetes with HPA, PodDisruptionBudgets, and multi-region Twilio failover.
+- Integrate OpenTelemetry collectors, Prometheus, Grafana, and Loki for full observability.
+- Conduct security reviews, penetration testing, and finalize compliance (privacy notices, data retention).
+
+## Key Design Decisions
+- **FastAPI** is used for all Python services to keep the stack consistent and lightweight.
+- **Twilio Programmable Voice** offers reliable PSTN coverage in Mexico and mature webhook support.
+- **Amazon Transcribe Streaming** and **Amazon Polly Neural** provide industry-leading quality for Spanish speech interfaces tailored to Mexican Spanish.
+- **OpenAI GPT-4o** is leveraged for high-quality bilingual reasoning with support for function-calling.
+- **PostgreSQL + Qdrant** give structured + semantic storage for conversational memory and RAG.
+- **Redis** acts as both the transient state store and Celery broker, simplifying early deployments.
+- **Docker Compose** accelerates local development; production will target Terraform-provisioned Kubernetes clusters.
+
+## Next Steps
+- Flesh out webhook handlers with Twilio signature validation and media streaming bridge.
+- Implement Redis-backed session manager and Celery worker scaffolding.
+- Add integration tests covering telephony event ingestion and conversation orchestration pathways.
+- Provide Terraform modules for core infrastructure (VPC, EKS/GKE, secrets, observability stack).
+
+## Contributing
+1. Create a feature branch from `main`.
+2. Implement changes with tests and documentation updates.
+3. Run `make lint` and `make format` before submitting a PR.
+4. Open a GitHub Pull Request describing your changes and referencing relevant Jira tickets.
+
+## License
+Distributed under the MIT License. See `LICENSE` (to be added) for more information.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - BROKER_URL=redis://redis:6379/0
     depends_on:
       - redis
+    restart: on-failure
 
   conversation-orchestrator:
     build: ./services/conversation_orchestrator
@@ -33,6 +34,7 @@ services:
       - DATABASE_URL=postgresql+psycopg2://voice_agent:voice_agent@postgres:5432/voice_agent
     depends_on:
       - postgres
+    restart: on-failure
 
   redis:
     image: redis:7.2-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+version: "3.9"
+
+services:
+  telephony-gateway:
+    build: ./services/telephony_gateway
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+    ports:
+      - "8080:8080"
+    environment:
+      - BROKER_URL=redis://redis:6379/0
+    depends_on:
+      - redis
+
+  conversation-orchestrator:
+    build: ./services/conversation_orchestrator
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8081"]
+    ports:
+      - "8081:8081"
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+      - OPENAI_API_KEY=changeme
+      - KNOWLEDGE_BASE_URL=http://qdrant:6333
+    depends_on:
+      - redis
+      - qdrant
+
+  backend-api:
+    build: ./services/backend_api
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8082"]
+    ports:
+      - "8082:8082"
+    environment:
+      - DATABASE_URL=postgresql+psycopg2://voice_agent:voice_agent@postgres:5432/voice_agent
+    depends_on:
+      - postgres
+
+  redis:
+    image: redis:7.2-alpine
+    ports:
+      - "6379:6379"
+
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: voice_agent
+      POSTGRES_PASSWORD: voice_agent
+      POSTGRES_DB: voice_agent
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  qdrant:
+    image: qdrant/qdrant:v1.7.3
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_storage:/qdrant/storage
+
+volumes:
+  postgres_data:
+  qdrant_storage:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,36 @@
+# System Architecture Overview
+
+## Component Map
+- **Telephony Gateway (FastAPI + Twilio Voice)** – Handles PSTN ingress/egress, normalizes webhooks, streams audio through WebSockets, and enforces compliance prompts for Mexican calls.
+- **Conversation Orchestrator (FastAPI)** – Maintains dialogue state, coordinates between LLM reasoning (OpenAI GPT-4o) and deterministic flows, and handles Spanish SSML generation.
+- **Session Store (Redis + Postgres)** – Redis caches active turn-by-turn context while Postgres stores long-lived transcripts for analytics.
+- **Speech Services** – Integrates Amazon Transcribe Streaming for low-latency transcription and Amazon Polly Neural for natural Spanish voices. Audio is piped through the telephony gateway.
+- **Backend API (FastAPI + Postgres)** – Persists contacts, call outcomes, transcripts, and integrates with CRM/ERP connectors through REST/GraphQL clients.
+- **Knowledge Base (Qdrant + Postgres)** – Hybrid retrieval of factual data with vector and structured storage for RAG.
+- **Asynchronous Tasks (Celery + Redis)** – Final transcription cleanup, analytics aggregation, CRM synchronization.
+- **Observability (OpenTelemetry + Prometheus + Grafana)** – Distributed traces, metrics, and dashboards for SLA enforcement.
+
+## Data Flow Summary
+1. Outbound dial initiated from campaign scheduler triggers Twilio REST API, connecting to telephony gateway.
+2. Gateway streams audio to Amazon Transcribe; transcripts are ingested by the conversation orchestrator via Redis pub/sub.
+3. Orchestrator queries Qdrant/Postgres for context, crafts prompts for GPT-4o, and returns Spanish responses with SSML cues.
+4. Amazon Polly synthesizes speech; telephony gateway feeds audio back to Twilio's <Play> or `<Stream>` instructions.
+5. Backend API logs structured conversation data, stores audio/transcripts in object storage (S3-compatible), and issues webhooks to downstream systems.
+6. Celery workers process follow-up tasks and emit metrics to Prometheus via OpenTelemetry exporters.
+
+### Dialogue Management
+- Slot-filling pipeline gathers `customer_name`, `intent`, and `callback_number` before escalating to LLM reasoning.
+- GPT-4o mini model produces empathetic Spanish responses using gathered slots as context, returning SSML hints for the telephony gateway.
+- Transcript segments are persisted after each turn for QA and retrieval workflows.
+
+## Scaling Considerations
+- Stateless FastAPI services packaged in containers; orchestrated via Kubernetes with HPA based on CPU and queue depth.
+- Redis and Postgres deployed as managed services (e.g., AWS ElastiCache and RDS) for high availability.
+- Media streaming separated into dedicated pods with autoscaling to manage bandwidth-intensive workloads.
+- Multi-region Twilio routing with failover DID numbers to comply with Mexican latency and redundancy requirements.
+
+## Security & Compliance
+- Secrets managed through AWS Secrets Manager with per-service IAM roles.
+- TLS everywhere; webhook signature validation for Twilio.
+- PII encrypted at rest (Postgres pgcrypto) and redacted in logs via OpenTelemetry processors.
+- Data residency respected by storing call data in compliant regions (Mexico/US).

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,12 @@
+# Terraform Infrastructure Modules (Placeholder)
+
+This directory will contain Terraform modules for provisioning the core cloud infrastructure required by the voice agent platform, including:
+
+- Networking (VPC, subnets, security groups, NAT gateways)
+- Kubernetes cluster (EKS/GKE) and node groups
+- Managed data services (RDS for PostgreSQL, ElastiCache/MemoryStore for Redis, Qdrant)
+- Observability stack (OpenTelemetry Collector, Prometheus, Grafana, Loki)
+- Secrets management (AWS Secrets Manager / GCP Secret Manager)
+- Telephony provider webhooks (API Gateway + Lambda or Cloud Run)
+
+Modules will be structured for reuse across staging and production environments with environment-specific variable files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "voice-agent-caller"
+version = "0.1.0"
+description = "Modular voice agent platform for outbound calling in Mexico"
+authors = [{ name = "Voice Agent Team" }]
+requires-python = ">=3.11"
+readme = "README.md"
+
+[project.optional-dependencies]
+dev = [
+    "ruff==0.4.3",
+    "pytest==8.2.1"
+]
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "B", "UP", "N", "ASYNC"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/services/backend_api/Dockerfile
+++ b/services/backend_api/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY app ./app
+
+ENV PYTHONPATH=/app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8082"]

--- a/services/backend_api/app/database.py
+++ b/services/backend_api/app/database.py
@@ -1,0 +1,11 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DEFAULT_DATABASE_URL = "postgresql+psycopg2://voice_agent:voice_agent@postgres:5432/voice_agent"
+DATABASE_URL = os.getenv("DATABASE_URL", DEFAULT_DATABASE_URL)
+
+engine = create_engine(DATABASE_URL, echo=False, future=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/services/backend_api/app/main.py
+++ b/services/backend_api/app/main.py
@@ -1,0 +1,109 @@
+from fastapi import Depends, FastAPI, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import Base, SessionLocal, engine
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Voice Agent Backend API", version="0.1.0")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/contacts", response_model=schemas.Contact, status_code=201)
+def create_contact(contact: schemas.ContactCreate, db: Session = Depends(get_db)) -> schemas.Contact:
+    db_contact = models.Contact(**contact.model_dump())
+    db.add(db_contact)
+    db.commit()
+    db.refresh(db_contact)
+    return schemas.Contact.model_validate(db_contact)
+
+
+@app.get("/contacts/{contact_id}", response_model=schemas.Contact)
+def read_contact(contact_id: int, db: Session = Depends(get_db)) -> schemas.Contact:
+    instance = db.get(models.Contact, contact_id)
+    if instance is None:
+        raise HTTPException(status_code=404, detail="Contact not found")
+    return schemas.Contact.model_validate(instance)
+
+
+@app.put("/sessions/{session_id}", response_model=schemas.CallSession)
+def upsert_session(
+    session_id: str, payload: schemas.SessionUpsert, db: Session = Depends(get_db)
+) -> schemas.CallSession:
+    stmt = select(models.CallSession).where(models.CallSession.session_id == session_id)
+    instance = db.execute(stmt).scalar_one_or_none()
+    if instance is None:
+        instance = models.CallSession(session_id=session_id, attributes=payload.attributes)
+        db.add(instance)
+    else:
+        instance.attributes = payload.attributes or {}
+    db.commit()
+    db.refresh(instance)
+    return schemas.CallSession.model_validate(instance)
+
+
+@app.get("/sessions/{session_id}", response_model=schemas.CallSession)
+def read_session(session_id: str, db: Session = Depends(get_db)) -> schemas.CallSession:
+    stmt = select(models.CallSession).where(models.CallSession.session_id == session_id)
+    instance = db.execute(stmt).scalar_one_or_none()
+    if instance is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return schemas.CallSession.model_validate(instance)
+
+
+@app.post(
+    "/sessions/{session_id}/transcripts",
+    response_model=schemas.TranscriptSegment,
+    status_code=201,
+)
+def append_transcript_segment(
+    session_id: str,
+    segment: schemas.TranscriptSegmentCreate,
+    db: Session = Depends(get_db),
+) -> schemas.TranscriptSegment:
+    stmt = select(models.CallSession).where(models.CallSession.session_id == session_id)
+    session = db.execute(stmt).scalar_one_or_none()
+    if session is None:
+        session = models.CallSession(session_id=session_id, attributes={})
+        db.add(session)
+        db.flush()
+
+    db_segment = models.TranscriptSegment(
+        session_id=session_id,
+        sequence=segment.sequence,
+        role=segment.role,
+        content=segment.content,
+        locale=segment.locale,
+    )
+    db.add(db_segment)
+    db.commit()
+    db.refresh(db_segment)
+    return schemas.TranscriptSegment.model_validate(db_segment)
+
+
+@app.get(
+    "/sessions/{session_id}/transcripts",
+    response_model=list[schemas.TranscriptSegment],
+)
+def list_transcripts(session_id: str, db: Session = Depends(get_db)) -> list[schemas.TranscriptSegment]:
+    stmt = (
+        select(models.TranscriptSegment)
+        .where(models.TranscriptSegment.session_id == session_id)
+        .order_by(models.TranscriptSegment.sequence.asc())
+    )
+    records = db.execute(stmt).scalars().all()
+    return [schemas.TranscriptSegment.model_validate(row) for row in records]
+
+
+@app.get("/healthz")
+def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}

--- a/services/backend_api/app/models.py
+++ b/services/backend_api/app/models.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, JSON, String, Text, func
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class Contact(Base):
+    __tablename__ = "contacts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    phone_number = Column(String, nullable=False, index=True)
+    name = Column(String, nullable=True)
+    email = Column(String, nullable=True)
+    notes = Column(String, nullable=True)
+
+
+class CallSession(Base):
+    __tablename__ = "call_sessions"
+
+    id = Column(Integer, primary_key=True)
+    session_id = Column(String, unique=True, index=True, nullable=False)
+    attributes = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    transcripts = relationship("TranscriptSegment", back_populates="session", cascade="all, delete")
+
+
+class TranscriptSegment(Base):
+    __tablename__ = "transcript_segments"
+
+    id = Column(Integer, primary_key=True)
+    session_id = Column(String, ForeignKey("call_sessions.session_id"), nullable=False, index=True)
+    sequence = Column(Integer, nullable=False)
+    role = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+    locale = Column(String, nullable=False, default="es-MX")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    session = relationship("CallSession", back_populates="transcripts")

--- a/services/backend_api/app/schemas.py
+++ b/services/backend_api/app/schemas.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ContactBase(BaseModel):
+    phone_number: str = Field(description="E.164 formatted phone number")
+    name: str | None = Field(default=None)
+    email: str | None = Field(default=None)
+    notes: str | None = Field(default=None)
+
+
+class ContactCreate(ContactBase):
+    pass
+
+
+class Contact(ContactBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+class SessionUpsert(BaseModel):
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class CallSession(BaseModel):
+    session_id: str
+    attributes: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class TranscriptSegmentCreate(BaseModel):
+    role: str
+    content: str
+    sequence: int
+    locale: str = Field(default="es-MX")
+
+
+class TranscriptSegment(BaseModel):
+    id: int
+    session_id: str
+    sequence: int
+    role: str
+    content: str
+    locale: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/services/backend_api/requirements.txt
+++ b/services/backend_api/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pydantic==2.7.1
+SQLAlchemy==2.0.29
+psycopg2-binary==2.9.9
+alembic==1.13.1

--- a/services/conversation_orchestrator/Dockerfile
+++ b/services/conversation_orchestrator/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+ENV PYTHONPATH=/app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8081"]

--- a/services/conversation_orchestrator/app/config.py
+++ b/services/conversation_orchestrator/app/config.py
@@ -1,0 +1,23 @@
+from functools import lru_cache
+
+from pydantic import Field, HttpUrl
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    redis_url: str = Field(default="redis://localhost:6379/0", alias="REDIS_URL")
+    redis_ttl_seconds: int = Field(default=3600, alias="SESSION_TTL_SECONDS")
+    openai_api_key: str | None = Field(default=None, alias="OPENAI_API_KEY")
+    backend_api_url: HttpUrl | str = Field(
+        default="http://backend-api:8082", alias="BACKEND_API_URL"
+    )
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        populate_by_name = True
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/services/conversation_orchestrator/app/dialogue.py
+++ b/services/conversation_orchestrator/app/dialogue.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+from .llm import LLMClient
+from .schemas import ConversationMessage, SessionState
+
+
+@dataclass(frozen=True)
+class SlotDefinition:
+    name: str
+    prompt: str
+    hint: str
+
+
+SLOT_DEFINITIONS: OrderedDict[str, SlotDefinition] = OrderedDict(
+    [
+        (
+            "customer_name",
+            SlotDefinition(
+                name="customer_name",
+                prompt="¿Con quién tengo el gusto? Necesito su nombre completo, por favor.",
+                hint="nombre",
+            ),
+        ),
+        (
+            "intent",
+            SlotDefinition(
+                name="intent",
+                prompt="¿En qué puedo apoyarte hoy?",
+                hint="motivo",
+            ),
+        ),
+        (
+            "callback_number",
+            SlotDefinition(
+                name="callback_number",
+                prompt="¿Cuál es un número telefónico de contacto en México?",
+                hint="teléfono",
+            ),
+        ),
+    ]
+)
+
+
+class DialogueManager:
+    """Hybrid dialogue policy with deterministic slots and LLM fallback."""
+
+    def __init__(self, llm_client: LLMClient | None = None) -> None:
+        self._llm = llm_client
+
+    async def handle_turn(
+        self,
+        state: SessionState,
+        user_input: str,
+        metadata: dict[str, Any],
+    ) -> tuple[SessionState, str, dict[str, Any]]:
+        state.history.append(ConversationMessage(role="user", content=user_input))
+        self._apply_heuristics(state, user_input, metadata)
+
+        next_slot = self._next_missing_slot(state)
+        if next_slot:
+            definition = SLOT_DEFINITIONS[next_slot]
+            response_text = definition.prompt
+            directives = {"expected_slot": next_slot, "speaking_style": "conversational"}
+        else:
+            state.status = "ready"
+            response_text = await self._generate_llm_response(state)
+            directives = {"speaking_style": "empathetic"}
+
+        state.history.append(ConversationMessage(role="assistant", content=response_text))
+        state.turn_index += 1
+        return state, response_text, directives
+
+    def _next_missing_slot(self, state: SessionState) -> str | None:
+        for slot_name in SLOT_DEFINITIONS:
+            if slot_name not in state.slots:
+                return slot_name
+        return None
+
+    def _apply_heuristics(self, state: SessionState, user_input: str, metadata: dict[str, Any]) -> None:
+        lowered = user_input.lower()
+        if "customer_name" not in state.slots:
+            name = self._extract_name(lowered)
+            if not name:
+                name = metadata.get("caller_name")
+            if name:
+                state.slots["customer_name"] = name.title()
+
+        if "intent" not in state.slots:
+            intent = self._extract_intent(lowered)
+            if intent:
+                state.slots["intent"] = intent
+
+        if "callback_number" not in state.slots:
+            phone = self._extract_phone(lowered)
+            if phone:
+                state.slots["callback_number"] = phone
+
+    @staticmethod
+    def _extract_name(text: str) -> str | None:
+        match = re.search(r"me llamo\s+([a-záéíóúñ\s]+)", text)
+        if match:
+            return match.group(1).strip()
+        match = re.search(r"soy\s+([a-záéíóúñ\s]+)", text)
+        if match:
+            return match.group(1).strip()
+        return None
+
+    @staticmethod
+    def _extract_intent(text: str) -> str | None:
+        keywords = {
+            "factura": "consultar factura",
+            "pago": "aclaración de pagos",
+            "soporte": "soporte técnico",
+            "cita": "agendar cita",
+            "información": "solicitar información",
+        }
+        for keyword, value in keywords.items():
+            if keyword in text:
+                return value
+        return None
+
+    @staticmethod
+    def _extract_phone(text: str) -> str | None:
+        digits = re.findall(r"\b(\d{10})\b", text)
+        if digits:
+            return digits[0]
+        return None
+
+    async def _generate_llm_response(self, state: SessionState) -> str:
+        if self._llm is None:
+            return "Perfecto, permíteme validar la información y enseguida continúo contigo."
+
+        prompt_messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Eres una agente telefónica mexicana, empática y profesional. "
+                    "Confirma datos capturados y ofrece pasos siguientes de forma clara."
+                ),
+            }
+        ]
+        for message in state.history[-6:]:
+            prompt_messages.append({"role": message.role, "content": message.content})
+
+        slots_summary = ", ".join(f"{k}: {v}" for k, v in state.slots.items())
+        prompt_messages.append(
+            {
+                "role": "system",
+                "content": f"Datos recopilados hasta ahora: {slots_summary if slots_summary else 'ninguno'}",
+            }
+        )
+
+        return await self._llm.generate_response(prompt_messages)

--- a/services/conversation_orchestrator/app/llm.py
+++ b/services/conversation_orchestrator/app/llm.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from openai import AsyncOpenAI
+
+
+class LLMClient:
+    """Wrapper around OpenAI responses API with graceful fallback."""
+
+    def __init__(self, api_key: str | None) -> None:
+        self._api_key = api_key
+        self._client = AsyncOpenAI(api_key=api_key) if api_key else None
+
+    async def generate_response(self, messages: Sequence[dict[str, str]]) -> str:
+        if self._client is None:
+            return "Gracias por la información. Procederé con los siguientes pasos y te mantendré al tanto."
+
+        completion = await self._client.responses.create(
+            model="gpt-4o-mini",
+            input=messages,
+            temperature=0.3,
+        )
+        return completion.output_text or "Entendido, continuaré ayudándote con gusto."

--- a/services/conversation_orchestrator/app/main.py
+++ b/services/conversation_orchestrator/app/main.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, HTTPException
+import redis.asyncio as redis
+
+from .config import get_settings
+from .dialogue import DialogueManager
+from .llm import LLMClient
+from .persistence import TranscriptLogger
+from .schemas import ConversationRequest, ConversationResponse, SessionState
+from .state import SessionStateStore
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Conversation Orchestrator", version="0.2.0")
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    settings = get_settings()
+    app.state.settings = settings
+    app.state.redis = redis.from_url(settings.redis_url, decode_responses=True)
+    app.state.state_store = SessionStateStore(app.state.redis, settings.redis_ttl_seconds)
+    app.state.llm = LLMClient(settings.openai_api_key)
+    app.state.dialogue = DialogueManager(app.state.llm)
+    app.state.transcript_logger = TranscriptLogger(str(settings.backend_api_url))
+    logger.info("Conversation orchestrator ready")
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await app.state.transcript_logger.close()
+    await app.state.redis.close()
+    await app.state.redis.wait_closed()
+
+
+@app.post("/conversation", response_model=ConversationResponse)
+async def converse(request: ConversationRequest) -> ConversationResponse:
+    if not request.user_input.strip():
+        raise HTTPException(status_code=400, detail="user_input cannot be empty")
+
+    state: SessionState = await app.state.state_store.load(request.session_id)
+    if request.locale:
+        state.locale = request.locale
+
+    attributes = {"metadata": request.metadata, "slots": state.slots, "locale": state.locale}
+    await app.state.transcript_logger.ensure_session(request.session_id, attributes)
+
+    current_turn = state.turn_index
+    updated_state, response_text, directives = await app.state.dialogue.handle_turn(
+        state, request.user_input, request.metadata
+    )
+    await app.state.state_store.save(updated_state)
+    await app.state.transcript_logger.ensure_session(
+        request.session_id,
+        {"metadata": request.metadata, "slots": updated_state.slots, "locale": updated_state.locale},
+    )
+
+    # Persist user/assistant transcript segments
+    user_message = updated_state.history[-2]
+    assistant_message = updated_state.history[-1]
+    await app.state.transcript_logger.append_segment(
+        request.session_id,
+        role=user_message.role,
+        content=user_message.content,
+        sequence=current_turn * 2,
+        locale=updated_state.locale,
+    )
+    await app.state.transcript_logger.append_segment(
+        request.session_id,
+        role=assistant_message.role,
+        content=assistant_message.content,
+        sequence=current_turn * 2 + 1,
+        locale=updated_state.locale,
+    )
+
+    return ConversationResponse(
+        session_id=request.session_id,
+        response_text=response_text,
+        ssml=directives.get("ssml"),
+        state=updated_state,
+        directives=directives,
+    )
+
+
+@app.get("/sessions/{session_id}", response_model=SessionState)
+async def get_session(session_id: str) -> SessionState:
+    state = await app.state.state_store.load(session_id)
+    return state
+
+
+@app.get("/healthz")
+async def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}

--- a/services/conversation_orchestrator/app/persistence.py
+++ b/services/conversation_orchestrator/app/persistence.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class TranscriptLogger:
+    """Persists session metadata and transcript segments via the backend API."""
+
+    def __init__(self, base_url: str, *, timeout: float = 10.0) -> None:
+        self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout)
+
+    async def ensure_session(self, session_id: str, attributes: dict[str, Any]) -> None:
+        response = await self._client.put(f"/sessions/{session_id}", json={"attributes": attributes})
+        response.raise_for_status()
+
+    async def append_segment(
+        self,
+        session_id: str,
+        *,
+        role: str,
+        content: str,
+        sequence: int,
+        locale: str,
+    ) -> None:
+        payload = {
+            "role": role,
+            "content": content,
+            "sequence": sequence,
+            "locale": locale,
+        }
+        response = await self._client.post(
+            f"/sessions/{session_id}/transcripts",
+            json=payload,
+        )
+        response.raise_for_status()
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/services/conversation_orchestrator/app/schemas.py
+++ b/services/conversation_orchestrator/app/schemas.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ConversationMessage(BaseModel):
+    role: Literal["user", "assistant", "system"]
+    content: str
+
+
+class SessionState(BaseModel):
+    session_id: str
+    locale: str = "es-MX"
+    status: Literal["collecting", "ready", "complete"] = "collecting"
+    slots: dict[str, str] = Field(default_factory=dict)
+    history: list[ConversationMessage] = Field(default_factory=list)
+    turn_index: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ConversationRequest(BaseModel):
+    session_id: str
+    user_input: str
+    locale: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ConversationResponse(BaseModel):
+    session_id: str
+    response_text: str
+    ssml: str | None = None
+    state: SessionState
+    directives: dict[str, Any] = Field(default_factory=dict)

--- a/services/conversation_orchestrator/app/state.py
+++ b/services/conversation_orchestrator/app/state.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from redis.asyncio import Redis
+
+from .schemas import SessionState
+
+
+class SessionStateStore:
+    """Redis-backed storage for conversation state."""
+
+    def __init__(self, client: Redis, ttl_seconds: int) -> None:
+        self._client = client
+        self._ttl = ttl_seconds
+
+    async def load(self, session_id: str) -> SessionState:
+        raw = await self._client.get(self._key(session_id))
+        if raw:
+            return SessionState.model_validate_json(raw)
+        return SessionState(session_id=session_id)
+
+    async def save(self, state: SessionState) -> SessionState:
+        state.updated_at = datetime.utcnow()
+        await self._client.set(
+            self._key(state.session_id),
+            state.model_dump_json(),
+            ex=self._ttl,
+        )
+        return state
+
+    async def delete(self, session_id: str) -> None:
+        await self._client.delete(self._key(session_id))
+
+    def _key(self, session_id: str) -> str:
+        return f"conversation:session:{session_id}"

--- a/services/conversation_orchestrator/requirements.txt
+++ b/services/conversation_orchestrator/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pydantic==2.7.1
+httpx==0.27.0
+openai==1.30.1
+redis==5.0.4
+pydantic-settings==2.2.1

--- a/services/telephony_gateway/Dockerfile
+++ b/services/telephony_gateway/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt ./
+RUN apt-get update && apt-get install -y cmake && apt-get clean
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app

--- a/services/telephony_gateway/Dockerfile
+++ b/services/telephony_gateway/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+ENV PYTHONPATH=/app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/telephony_gateway/app/config.py
+++ b/services/telephony_gateway/app/config.py
@@ -1,0 +1,32 @@
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import Field, HttpUrl
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Runtime configuration for the telephony gateway service."""
+
+    redis_url: str = Field(default="redis://localhost:6379/0", alias="REDIS_URL")
+    orchestrator_url: HttpUrl | str = Field(
+        default="http://conversation-orchestrator:8081", alias="ORCHESTRATOR_URL"
+    )
+    backend_api_url: HttpUrl | str = Field(
+        default="http://backend-api:8082", alias="BACKEND_API_URL"
+    )
+    aws_region: str = Field(default="us-east-1", alias="AWS_REGION")
+    polly_voice_id: str = Field(default="Lucia", alias="POLLY_VOICE_ID")
+    polly_engine: Literal["standard", "neural"] = Field(default="neural", alias="POLLY_ENGINE")
+    transcribe_language_code: str = Field(default="es-MX", alias="TRANSCRIBE_LANGUAGE_CODE")
+    audio_cache_ttl_seconds: int = Field(default=3600, alias="AUDIO_CACHE_TTL")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        populate_by_name = True
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/services/telephony_gateway/app/conversation.py
+++ b/services/telephony_gateway/app/conversation.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class ConversationClient:
+    """Thin wrapper around the conversation orchestrator HTTP API."""
+
+    def __init__(self, base_url: str, *, timeout: float = 10.0) -> None:
+        self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout)
+
+    async def advance(self, session_id: str, user_input: str, locale: str | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {"session_id": session_id, "user_input": user_input}
+        if locale:
+            payload["locale"] = locale
+        response = await self._client.post("/conversation", json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/services/telephony_gateway/app/events.py
+++ b/services/telephony_gateway/app/events.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from redis.asyncio import Redis
+
+
+@dataclass
+class RedisEventBus:
+    """Publish-only event bus backed by Redis channels."""
+
+    client: Redis
+    channel_prefix: str = "telephony"
+
+    async def publish(self, topic: str, payload: dict) -> None:
+        channel = f"{self.channel_prefix}:{topic}"
+        message = json.dumps(payload, default=str)
+        await self.client.publish(channel, message)

--- a/services/telephony_gateway/app/main.py
+++ b/services/telephony_gateway/app/main.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
+import redis.asyncio as redis
+
+from .config import Settings, get_settings
+from .conversation import ConversationClient
+from .events import RedisEventBus
+from .persistence import SessionPersistenceClient
+from .schemas import ConversationResult, StreamRequest, VoiceResponse
+from .speech import SpeechPipeline
+from .transcribe import TranscribeStreamingService
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Telephony Gateway", version="0.2.0")
+
+
+async def _parse_twilio_payload(request: Request) -> dict[str, Any]:
+    content_type = request.headers.get("content-type", "")
+    if "application/json" in content_type:
+        return await request.json()
+    form = await request.form()
+    return {key: value for key, value in form.multi_items()}
+
+
+def _resolve_locale(payload: dict[str, Any], settings: Settings) -> str:
+    return payload.get("Language") or payload.get("locale") or settings.transcribe_language_code
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    settings = get_settings()
+    app.state.settings = settings
+    app.state.redis = redis.from_url(settings.redis_url, decode_responses=True)
+    app.state.event_bus = RedisEventBus(app.state.redis)
+    app.state.conversation = ConversationClient(str(settings.orchestrator_url))
+    app.state.persistence = SessionPersistenceClient(str(settings.backend_api_url))
+    app.state.speech_pipeline = SpeechPipeline(settings, app.state.redis)
+    app.state.transcribe = TranscribeStreamingService(settings)
+    logger.info("Telephony gateway started with region %s", settings.aws_region)
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await app.state.conversation.close()
+    await app.state.persistence.close()
+    await app.state.redis.close()
+    await app.state.redis.wait_closed()
+
+
+@app.post("/twilio/webhook/voice", response_model=VoiceResponse)
+async def handle_twilio_voice(
+    request: Request, background_tasks: BackgroundTasks
+) -> VoiceResponse:
+    payload = await _parse_twilio_payload(request)
+    call_sid = payload.get("CallSid") or payload.get("call_sid")
+    if not call_sid:
+        raise HTTPException(status_code=400, detail="Missing CallSid from payload")
+
+    background_tasks.add_task(app.state.event_bus.publish, "call.events", payload)
+    await app.state.persistence.upsert_session(
+        call_sid, {"provider_payload": payload, "locale": _resolve_locale(payload, app.state.settings)}
+    )
+
+    speech_result = payload.get("SpeechResult") or payload.get("speech_result")
+    if speech_result:
+        locale = _resolve_locale(payload, app.state.settings)
+        orchestrator_raw = await app.state.conversation.advance(call_sid, speech_result, locale=locale)
+        orchestrator = ConversationResult.model_validate(orchestrator_raw)
+        audio = await app.state.speech_pipeline.synthesize(
+            orchestrator.response_text,
+            speaking_style=orchestrator.directives.get("speaking_style"),
+        )
+        return VoiceResponse(
+            action="play_audio",
+            metadata={"provider": "twilio", "call_sid": call_sid},
+            response_text=orchestrator.response_text,
+            audio_base64=audio.audio_base64,
+            ssml=audio.ssml,
+        )
+
+    return VoiceResponse(
+        action="ack",
+        metadata={"provider": "twilio", "call_sid": call_sid},
+    )
+
+
+@app.post("/twilio/webhook/status", response_model=VoiceResponse)
+async def handle_twilio_status(request: Request, background_tasks: BackgroundTasks) -> VoiceResponse:
+    payload = await _parse_twilio_payload(request)
+    background_tasks.add_task(app.state.event_bus.publish, "call.status", payload)
+    call_sid = payload.get("CallSid") or payload.get("call_sid")
+    return VoiceResponse(action="ack", metadata={"provider": "twilio", "call_sid": call_sid})
+
+
+@app.post("/twilio/stream", response_model=VoiceResponse)
+async def handle_twilio_stream(stream_request: StreamRequest, background_tasks: BackgroundTasks) -> VoiceResponse:
+    if not stream_request.audio_chunks:
+        raise HTTPException(status_code=400, detail="audio_chunks payload is required")
+
+    call_sid = stream_request.call_sid
+    locale = stream_request.locale or app.state.settings.transcribe_language_code
+    audio_bytes = app.state.transcribe.decode_chunks(stream_request.audio_chunks)
+    transcript = await app.state.transcribe.transcribe_audio(
+        audio_bytes,
+        sample_rate_hz=stream_request.sample_rate_hz,
+        encoding=stream_request.encoding,
+    )
+
+    if not transcript:
+        return VoiceResponse(
+            action="ack",
+            metadata={"provider": "twilio", "call_sid": call_sid, "locale": locale},
+        )
+
+    event_payload = {
+        "CallSid": call_sid,
+        "transcript": transcript,
+        "metadata": stream_request.metadata,
+        "source": "media_stream",
+    }
+    background_tasks.add_task(app.state.event_bus.publish, "call.stream", event_payload)
+
+    await app.state.persistence.upsert_session(
+        call_sid,
+        {
+            "transcript": transcript,
+            "locale": locale,
+            "metadata": stream_request.metadata,
+        },
+    )
+
+    orchestrator_raw = await app.state.conversation.advance(call_sid, transcript, locale=locale)
+    orchestrator = ConversationResult.model_validate(orchestrator_raw)
+    audio = await app.state.speech_pipeline.synthesize(
+        orchestrator.response_text,
+        speaking_style=orchestrator.directives.get("speaking_style"),
+    )
+
+    return VoiceResponse(
+        action="play_audio",
+        metadata={"provider": "twilio", "call_sid": call_sid, "locale": locale},
+        response_text=orchestrator.response_text,
+        audio_base64=audio.audio_base64,
+        ssml=audio.ssml,
+    )
+
+
+@app.get("/healthz")
+async def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}

--- a/services/telephony_gateway/app/persistence.py
+++ b/services/telephony_gateway/app/persistence.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class SessionPersistenceClient:
+    """Handles call session lifecycle persistence via the backend API."""
+
+    def __init__(self, base_url: str, *, timeout: float = 10.0) -> None:
+        self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout)
+
+    async def upsert_session(self, session_id: str, attributes: dict[str, Any]) -> None:
+        response = await self._client.put(f"/sessions/{session_id}", json={"attributes": attributes})
+        response.raise_for_status()
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/services/telephony_gateway/app/schemas.py
+++ b/services/telephony_gateway/app/schemas.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class VoiceResponse(BaseModel):
+    """Envelope returned to the telephony provider webhooks."""
+
+    action: str = Field(description="Type of response action for the provider")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    response_text: str | None = Field(
+        default=None, description="Plain-text response delivered back to the caller"
+    )
+    audio_base64: str | None = Field(
+        default=None,
+        description="Base64-encoded audio (mp3) synthesized for playback",
+    )
+    ssml: str | None = Field(
+        default=None, description="SSML used to synthesize the audio response"
+    )
+
+
+class ConversationResult(BaseModel):
+    """Shape returned by the conversation orchestrator service."""
+
+    session_id: str
+    response_text: str
+    ssml: str | None = None
+    state: dict[str, Any]
+    directives: dict[str, Any] = Field(default_factory=dict)
+
+
+class StreamRequest(BaseModel):
+    """Payload sent by the media gateway to request transcription."""
+
+    call_sid: str = Field(description="Unique call session identifier")
+    audio_chunks: list[str] = Field(
+        default_factory=list,
+        description="List of base64 encoded audio chunks (PCM or Opus)",
+    )
+    sample_rate_hz: int = Field(default=8000, description="Sample rate of the input audio")
+    encoding: str = Field(default="pcm", description="Encoding of the audio stream")
+    locale: str | None = Field(default=None, description="Locale hint for transcription")
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/services/telephony_gateway/app/speech.py
+++ b/services/telephony_gateway/app/speech.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+from redis.asyncio import Redis
+
+from .config import Settings
+
+
+@dataclass
+class SynthesizedAudio:
+    """Container for synthesized speech ready for playback."""
+
+    ssml: str
+    audio_base64: str
+    format: str
+    voice_id: str
+
+
+class SpeechCache:
+    """Redis-backed cache to avoid re-synthesizing repeated prompts."""
+
+    def __init__(self, client: Redis, ttl_seconds: int) -> None:
+        self._client = client
+        self._ttl = ttl_seconds
+
+    async def get(self, key: str) -> str | None:
+        return await self._client.get(key)
+
+    async def set(self, key: str, value: str) -> None:
+        await self._client.set(key, value, ex=self._ttl)
+
+
+class PollySynthesizer:
+    """Wraps Amazon Polly neural voices."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._client = boto3.client("polly", region_name=settings.aws_region)
+        self._voice_id = settings.polly_voice_id
+        self._engine = settings.polly_engine
+        self._language = settings.transcribe_language_code
+
+    def synthesize(self, text_or_ssml: str, is_ssml: bool = True) -> bytes:
+        try:
+            response = self._client.synthesize_speech(
+                Text=text_or_ssml,
+                TextType="ssml" if is_ssml else "text",
+                OutputFormat="mp3",
+                VoiceId=self._voice_id,
+                Engine=self._engine,
+                LanguageCode=self._language,
+            )
+        except (BotoCoreError, ClientError) as exc:  # pragma: no cover - network failure path
+            raise RuntimeError("Failed to synthesize speech with Amazon Polly") from exc
+
+        audio_stream = response.get("AudioStream")
+        if audio_stream is None:  # pragma: no cover - safety check
+            raise RuntimeError("Amazon Polly did not return an audio stream")
+        return audio_stream.read()
+
+
+class SpeechPipeline:
+    """Coordinates caching and synthesis for Spanish agent responses."""
+
+    def __init__(self, settings: Settings, redis_client: Redis) -> None:
+        self._settings = settings
+        self._cache = SpeechCache(redis_client, settings.audio_cache_ttl_seconds)
+        self._synthesizer = PollySynthesizer(settings)
+
+    async def synthesize(self, response_text: str, *, speaking_style: str | None = None) -> SynthesizedAudio:
+        ssml = self._to_ssml(response_text, speaking_style=speaking_style)
+        cache_key = self._cache_key(ssml)
+
+        cached_audio = await self._cache.get(cache_key)
+        if cached_audio:
+            return SynthesizedAudio(
+                ssml=ssml,
+                audio_base64=cached_audio,
+                format="mp3",
+                voice_id=self._settings.polly_voice_id,
+            )
+
+        audio_bytes = self._synthesizer.synthesize(ssml, is_ssml=True)
+        encoded = base64.b64encode(audio_bytes).decode()
+        await self._cache.set(cache_key, encoded)
+        return SynthesizedAudio(
+            ssml=ssml,
+            audio_base64=encoded,
+            format="mp3",
+            voice_id=self._settings.polly_voice_id,
+        )
+
+    @staticmethod
+    def _cache_key(ssml: str) -> str:
+        digest = hashlib.sha1(ssml.encode("utf-8")).hexdigest()
+        return f"polly:ssml:{digest}"
+
+    @staticmethod
+    def _to_ssml(text: str, *, speaking_style: str | None = None) -> str:
+        style = speaking_style or "conversational"
+        return (
+            "<speak>"
+            f"<amazon:domain name=\"{style}\">{text}</amazon:domain>"
+            "</speak>"
+        )

--- a/services/telephony_gateway/app/transcribe.py
+++ b/services/telephony_gateway/app/transcribe.py
@@ -4,35 +4,16 @@ import asyncio
 import base64
 from typing import Iterable
 
-from amazon_transcribe.client import AmazonTranscribeStreamingClient
-from amazon_transcribe.handlers import TranscriptResultStreamHandler
-from amazon_transcribe.model import TranscriptEvent
+import boto3
 
 from .config import Settings
 
 
-class _TranscriptCollector(TranscriptResultStreamHandler):
-    def __init__(self, stream) -> None:  # type: ignore[override]
-        super().__init__(stream)
-        self._segments: list[str] = []
-
-    async def handle_transcript_event(self, transcript_event: TranscriptEvent) -> None:  # type: ignore[override]
-        for result in transcript_event.transcript.results:
-            if result.is_partial:
-                continue
-            if result.alternatives:
-                self._segments.append(result.alternatives[0].transcript)
-
-    @property
-    def transcript(self) -> str:
-        return " ".join(self._segments).strip()
-
-
 class TranscribeStreamingService:
-    """Thin wrapper around Amazon Transcribe streaming client."""
+    """Thin wrapper around Amazon Transcribe streaming client using boto3."""
 
     def __init__(self, settings: Settings) -> None:
-        self._client = AmazonTranscribeStreamingClient(region=settings.aws_region)
+        self._client = boto3.client('transcribe', region_name=settings.aws_region)
         self._language_code = settings.transcribe_language_code
 
     async def transcribe_audio(
@@ -42,7 +23,8 @@ class TranscribeStreamingService:
         sample_rate_hz: int,
         encoding: str = "pcm",
     ) -> str:
-        stream = await self._client.start_stream_transcription(
+        # Start the stream
+        stream = self._client.start_stream_transcription(
             language_code=self._language_code,
             media_sample_rate_hz=sample_rate_hz,
             media_encoding=encoding.upper(),
@@ -50,14 +32,27 @@ class TranscribeStreamingService:
             partial_results_stability="medium",
         )
 
-        async def _write_stream() -> None:
+        # Collect transcripts
+        transcripts = []
+
+        async def send_audio():
             for chunk in audio_chunks:
                 await stream.input_stream.send_audio_event(audio_chunk=chunk)
             await stream.input_stream.end_stream()
 
-        collector = _TranscriptCollector(stream.output_stream)
-        await asyncio.gather(_write_stream(), collector.run())
-        return collector.transcript
+        async def receive_transcripts():
+            async for event in stream.output_stream:
+                if 'Transcript' in event:
+                    results = event['Transcript']['Results']
+                    for result in results:
+                        if not result.get('IsPartial', False):
+                            alternatives = result.get('Alternatives', [])
+                            if alternatives:
+                                transcripts.append(alternatives[0]['Transcript'])
+
+        await asyncio.gather(send_audio(), receive_transcripts())
+
+        return " ".join(transcripts).strip()
 
     @staticmethod
     def decode_chunks(payload: Iterable[str]) -> list[bytes]:

--- a/services/telephony_gateway/app/transcribe.py
+++ b/services/telephony_gateway/app/transcribe.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import Iterable
+
+from amazon_transcribe.client import AmazonTranscribeStreamingClient
+from amazon_transcribe.handlers import TranscriptResultStreamHandler
+from amazon_transcribe.model import TranscriptEvent
+
+from .config import Settings
+
+
+class _TranscriptCollector(TranscriptResultStreamHandler):
+    def __init__(self, stream) -> None:  # type: ignore[override]
+        super().__init__(stream)
+        self._segments: list[str] = []
+
+    async def handle_transcript_event(self, transcript_event: TranscriptEvent) -> None:  # type: ignore[override]
+        for result in transcript_event.transcript.results:
+            if result.is_partial:
+                continue
+            if result.alternatives:
+                self._segments.append(result.alternatives[0].transcript)
+
+    @property
+    def transcript(self) -> str:
+        return " ".join(self._segments).strip()
+
+
+class TranscribeStreamingService:
+    """Thin wrapper around Amazon Transcribe streaming client."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._client = AmazonTranscribeStreamingClient(region=settings.aws_region)
+        self._language_code = settings.transcribe_language_code
+
+    async def transcribe_audio(
+        self,
+        audio_chunks: Iterable[bytes],
+        *,
+        sample_rate_hz: int,
+        encoding: str = "pcm",
+    ) -> str:
+        stream = await self._client.start_stream_transcription(
+            language_code=self._language_code,
+            media_sample_rate_hz=sample_rate_hz,
+            media_encoding=encoding.upper(),
+            enable_partial_results_stabilization=True,
+            partial_results_stability="medium",
+        )
+
+        async def _write_stream() -> None:
+            for chunk in audio_chunks:
+                await stream.input_stream.send_audio_event(audio_chunk=chunk)
+            await stream.input_stream.end_stream()
+
+        collector = _TranscriptCollector(stream.output_stream)
+        await asyncio.gather(_write_stream(), collector.run())
+        return collector.transcript
+
+    @staticmethod
+    def decode_chunks(payload: Iterable[str]) -> list[bytes]:
+        return [base64.b64decode(item) for item in payload]

--- a/services/telephony_gateway/requirements.txt
+++ b/services/telephony_gateway/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pydantic==2.7.1
+boto3==1.34.103
+httpx==0.27.0
+python-dotenv==1.0.1
+redis==5.0.4
+pydantic-settings==2.2.1
+amazon-transcribe==0.6.1

--- a/services/telephony_gateway/requirements.txt
+++ b/services/telephony_gateway/requirements.txt
@@ -6,4 +6,3 @@ httpx==0.27.0
 python-dotenv==1.0.1
 redis==5.0.4
 pydantic-settings==2.2.1
-amazon-transcribe==0.6.1


### PR DESCRIPTION
## Summary
- integrate the telephony gateway with Amazon Transcribe streaming and Polly synthesis, including Redis-backed audio caching and orchestration hooks
- implement the conversation orchestrator with Redis session storage, slot-filling dialogue manager, GPT-4o fallback, and transcript logging into the backend API
- extend the backend API to persist call sessions and transcript segments and update documentation to reflect the AWS-based speech stack and delivered phase 2 scope

## Testing
- not run (infrastructure and service scaffolding updates)

------
https://chatgpt.com/codex/tasks/task_e_68e02d179b5c8320b14eb4b5eb150a90